### PR TITLE
increase font-size

### DIFF
--- a/webpage/jupyter_notebook_jekyll_theme/_sass/_variables.scss
+++ b/webpage/jupyter_notebook_jekyll_theme/_sass/_variables.scss
@@ -39,7 +39,7 @@ $type-size-3                : 1.563em;  // ~25.008px
 $type-size-4                : 1.25em;   // ~20px
 $type-size-5                : 1em;      // ~16px
 $type-size-6                : 0.75em;   // ~12px
-$type-size-7                : 0.6875em; // ~11px
+$type-size-7                : 15px; // was 0.6875em (~11px)
 $type-size-8                : 0.625em;  // ~10px
 
 


### PR DESCRIPTION
@emiliom some external font probably changed and that is why we are getting the small font size in the highlight. I am not sure what changed so I modify it to be in pixels. Note that the original value of `was 0.6875em` was supposed to be `~11px`, I consider that too small and made it `15px`. What do you think?

![screenshot from 2017-11-10 08-51-23](https://user-images.githubusercontent.com/950575/32655415-8fe74a9a-c5f4-11e7-88b3-e3658f097543.png)